### PR TITLE
Make Ammoniacal fish breeding work like similar recipes

### DIFF
--- a/space_age_galore/prototypes/intermediates/organic.lua
+++ b/space_age_galore/prototypes/intermediates/organic.lua
@@ -85,6 +85,7 @@ vgal.data.extend({
             vgal.icon.get_in_fluid("ammoniacal-solution"),
         },
         category = "organic",
+        reset_freshness_on_craft = true,
         energy_required = 6,
         technology = "planet-discovery-aquilo",
         fluid_ingredients = {


### PR DESCRIPTION
All breeding/cultivation recipes in vanilla (like bacteria cultivation, pentapod egg breeding, and normal fish breeding) force the output to always be 100% freshness. Without this feature, it would be impossible to sustain a crafting loop indefinitely; the freshness of the outputs would slowly get worse and worse until they finally spoiled.

The ammoniacal fish breeding recipe doesn't reset the freshness like these other recipes. I think this is an oversight, and this PR just fixes that issue.